### PR TITLE
Edit form

### DIFF
--- a/app/assets/stylesheets/myfiles.scss
+++ b/app/assets/stylesheets/myfiles.scss
@@ -36,6 +36,11 @@
     box-sizing: border-box;
 
   }
+  .art-address {
+    height: 40px;
+    width: 100%;
+    font-size: 20px;
+  }
   .art-submit-container {
     text-align: center;
     #art-submit {
@@ -50,10 +55,21 @@
 
     }
   }
-  .art-address {
-    height: 40px;
-    width: 100%;
-    font-size: 20px;
+  .art-form-return-link {
+    text-align: center;
+    padding: auto;
+    text-decoration: none;
+    #art-form-return-link {
+      background-color: #eeeeee;
+      height: 50px;
+      width: 200px;
+      margin: 0 auto;
+      .art-form-return {
+        padding: 17px;
+        margin: 0 auto;
+
+      }
+    }
   }
 }
 .art-show-link {

--- a/app/assets/stylesheets/myfiles.scss
+++ b/app/assets/stylesheets/myfiles.scss
@@ -35,6 +35,9 @@
   #myfile_file {
     // display: none;
     box-sizing: border-box;
+    height: 30px;
+    width: 100%;
+    font-size: 100%;
 
   }
   .art-address {

--- a/app/assets/stylesheets/myfiles.scss
+++ b/app/assets/stylesheets/myfiles.scss
@@ -31,8 +31,9 @@
     width: 500px;
     border: 1px solid black;
   }
-  .art-document {
-    display: none;
+  
+  #myfile_file {
+    // display: none;
     box-sizing: border-box;
 
   }

--- a/app/assets/stylesheets/new.scss
+++ b/app/assets/stylesheets/new.scss
@@ -3,17 +3,19 @@
   h1 {
     font-size: 35px;
   }
-  .art-form-return-link {
-    text-decoration: none;
-    position: relative;
-    .art-form-return {
-      position: absolute;
-      text-decoration: none;
-      height: 50px;
-      width: 100px;
-      background-color: #eeeeee;
-      text-align: center;
+  // .art-form-return-link {
+  //   text-decoration: none;
+  //   position: relative;
+  //   // padding: 7px;
+  //   .art-form-return {
+  //     position: absolute;
+  //     text-decoration: none;
+  //     height: 50px;
+  //     width: 100px;
+  //     background-color: #eeeeee;
+  //     text-align: center;
+  //     padding: 50%;
       
-    }
-  }
+  //   }
+  // }
 }

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -7,11 +7,11 @@ body {
   line-height: 18px;
 }
 
-p, ol, ul, td {
-  font-family: verdana, arial, helvetica, sans-serif;
-  font-size: 13px;
-  line-height: 18px;
-}
+// p, ol, ul, td {
+//   font-family: verdana, arial, helvetica, sans-serif;
+//   font-size: 13px;
+//   line-height: 18px;
+// }
 
 pre {
   background-color: #eee;

--- a/app/views/myfiles/_form.html.haml
+++ b/app/views/myfiles/_form.html.haml
@@ -30,3 +30,7 @@
         = form.text_field :address, placeholder:"開催する住所を入力してください", class: "art-address"
     .art-submit-container
       = form.submit "作成", id:"art-submit"
+    = link_to(myfiles_path, class:"art-form-return-link") do
+      #art-form-return-link
+        .art-form-return
+          戻る

--- a/app/views/myfiles/_form.html.haml
+++ b/app/views/myfiles/_form.html.haml
@@ -23,7 +23,7 @@
         .art-file
           ここをクリックしてファイルをアップロードできます
 
-        = form.file_field :file, class:"art-document"
+        = form.file_field :file
     %div
       = form.label :address, "開催住所", class:"art-label" do
         %p.art-new-p 開催住所

--- a/app/views/myfiles/_form.html.haml
+++ b/app/views/myfiles/_form.html.haml
@@ -20,8 +20,8 @@
     %div
       = form.label :file, "資料を添付できます", class:"art-label" do
         %p.art-new-p 添付資料
-        .art-file
-          ここをクリックしてファイルをアップロードできます
+        -# .art-file
+        -#   ここをクリックしてファイルをアップロードできます
 
         = form.file_field :file
     %div

--- a/app/views/myfiles/edit.html.haml
+++ b/app/views/myfiles/edit.html.haml
@@ -1,5 +1,5 @@
 %h1 Editing Myfile
 = render 'form', myfile: @myfile
-= link_to 'Show', @myfile
-|
-= link_to 'Back', myfiles_path
+-# = link_to 'Show', @myfile
+-# |
+-# = link_to 'Back', myfiles_path

--- a/app/views/myfiles/new.html.haml
+++ b/app/views/myfiles/new.html.haml
@@ -1,8 +1,8 @@
 .art-new-wrapper
   %h1 新規記事作成
   = render 'form', myfile: @myfile
-  = link_to(myfiles_path, class:"art-form-return-link") do
-    #art-form-return-link
-      .art-form-return
-        戻る
+  -# = link_to(myfiles_path, class:"art-form-return-link") do
+  -#   #art-form-return-link
+  -#     .art-form-return
+  -#       戻る
     

--- a/app/views/myfiles/show.html.haml
+++ b/app/views/myfiles/show.html.haml
@@ -7,7 +7,7 @@
   .art-show-main__comment
     .item
       概要
-    = @myfile.comment
+    = simple_format(@myfile.comment)
   .art-show-main__document
     .item
       資料


### PR DESCRIPTION
# what
投稿フォームのファイルフィールドの形式を変更
入力欄の幅の調整

# why
ファイルフィールドにファイルをつけたときに、ファイル名が表示される方がファイルを添付したかわかりやすい。
住所の入力欄が小さすぎて、クリックや確認がしづらかったため。
