### PR TITLE
Edit attach  file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+
+user_name:       testuser
+e-mail address:  testuser@jungle.com
+password:        testuser

--- a/app/assets/stylesheets/index.scss
+++ b/app/assets/stylesheets/index.scss
@@ -16,7 +16,7 @@
           font-size: 25px;
           display: block;
           text-decoration: none;
-          margin-left: 10px;
+          margin: 0 10px;
         
           }
           .art-show-link:hover {

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -17,6 +17,9 @@
   .item {
       padding: 10px 0;
     }
+  // .none {
+    
+  // }
   #gmap {
     height: 300px;
     width: 400px;

--- a/app/controllers/myfiles_controller.rb
+++ b/app/controllers/myfiles_controller.rb
@@ -26,11 +26,12 @@ class MyfilesController < ApplicationController
   # POST /myfiles.json
   def create
     @myfile = Myfile.create(myfile_params)
-
-    file = myfile_params[:file]
-    file_name = file.original_filename
-    @myfile.filename= file.original_filename
-    result = uploadpdf(file,file_name)
+    if myfile_params[:file]
+      file = myfile_params[:file]
+      file_name = file.original_filename
+      @myfile.filename= file.original_filename
+      result = uploadpdf(file,file_name)
+    end
 
     respond_to do |format|
       if @myfile.save

--- a/app/views/myfiles/show.html.haml
+++ b/app/views/myfiles/show.html.haml
@@ -11,7 +11,11 @@
   .art-show-main__document
     .item
       資料
-    = link_to @myfile.filename ,donwload_pdf_path(@myfile), :class => 'btn btn-default btn-xs'
+    - if @myfile.filename
+      = link_to @myfile.filename ,donwload_pdf_path(@myfile), :class => 'btn btn-default btn-xs'
+    - else 
+      .none
+        添付資料はありません
   .art-show-main__address
     .item
       開催場所・住所


### PR DESCRIPTION
# what
記事作成時に添付資料を選択しなかった場合に、エラーになっていた問題の解決。
ファイルフィールドの見た目を変更。ファイル名を確認できるようにデフォルトの状態に。

# why
事前に資料を共有しない場合に、エラーが出ると記事作成ができない。適当なファイルを添付する必要があり、不便になるため。